### PR TITLE
feat(core): add appmode support for proxy requests

### DIFF
--- a/server/routes/store-api/category/[...].ts
+++ b/server/routes/store-api/category/[...].ts
@@ -20,6 +20,7 @@ export default defineCachedEventHandler(
         maxAge: 60 * 1 * 60,
         swr: true,
         varies: [
+            'user-agent',
             'sw-access-key',
             'sw-language-id',
             'x-env',

--- a/server/routes/store-api/country-state/[...].ts
+++ b/server/routes/store-api/country-state/[...].ts
@@ -16,6 +16,7 @@ export default defineCachedEventHandler(
         maxAge: 60 * 1 * 60,
         swr: true,
         varies: [
+            'user-agent',
             'sw-access-key',
             'sw-language-id',
             'x-env',

--- a/server/routes/store-api/country.ts
+++ b/server/routes/store-api/country.ts
@@ -15,6 +15,7 @@ export default defineCachedEventHandler(
         maxAge: 60 * 1 * 60,
         swr: true,
         varies: [
+            'user-agent',
             'sw-access-key',
             'sw-language-id',
             'x-env',

--- a/server/routes/store-api/language.ts
+++ b/server/routes/store-api/language.ts
@@ -15,6 +15,7 @@ export default defineCachedEventHandler(
         maxAge: 60 * 1 * 60,
         swr: true,
         varies: [
+            'user-agent',
             'sw-access-key',
             'sw-language-id',
             'x-env',

--- a/server/routes/store-api/navigation/[...].ts
+++ b/server/routes/store-api/navigation/[...].ts
@@ -24,6 +24,7 @@ export default defineCachedEventHandler(
         maxAge: 60 * 1 * 60,
         swr: true,
         varies: [
+            'user-agent',
             'sw-access-key',
             'sw-language-id',
             'x-env',

--- a/utils/usePrepareRequest.ts
+++ b/utils/usePrepareRequest.ts
@@ -18,6 +18,13 @@ export async function usePrepareRequest(event: H3Event) {
         }
     });
 
+    const userAgent = getRequestHeader(event, 'user-agent');
+    let appMode = 'storefront';
+    if (userAgent.includes('dart:io')) {
+        appMode = 'mobile';
+    }
+    requestHeaders['x-client-origin'] = appMode;
+
     const requestOptions = {
         cache: 'force-cache' as RequestCache,
         method: event.method,
@@ -38,8 +45,6 @@ export async function usePrepareRequest(event: H3Event) {
 
         if (contentType && contentType.startsWith('multipart/form-data')) {
             const formData = await readMultipartFormData(event);
-
-            console.log(formData);
 
             const requestFormData = new FormData();
             formData.forEach(({ name, data, filename, type }) => {


### PR DESCRIPTION
**Background:**

We're about to launch our own mobile application. To get usage stats about the mobile app we needed to find a way to identify requests using a certain criteria. After some research it appears that the user-agent from our mobile app that is written in Flutter is always using `Dart/<version> (dart:io)`

![Screenshot 2025-02-04 at 08 44 45](https://github.com/user-attachments/assets/44fac643-3f71-42fe-9596-ac6fb14f4f06)

**Solution:**

* Pass through user-agent request headers in all cached event handlers (otherwise the header is not available)
* Parse user-agent string and look for the string `dart:io`
   * If a user-agent contains this string, we'll set the `x-client-origin` header to `mobile`
   * Otherwise we're setting it to `storefront`

@michnhokn After deploying the PR, could you please check in Datadog / on the app server if we're getting the right information?