### PR TITLE
fix(core): passthrough headers for catch-all route

### DIFF
--- a/server/routes/store-api/[...].ts
+++ b/server/routes/store-api/[...].ts
@@ -1,8 +1,10 @@
-import { useSalesChannel } from '~~/utils/useSalesChannel';
+import { usePrepareRequest } from '~~/utils/usePrepareRequest';
 import { proxyRequest } from '#imports';
 
 export default defineEventHandler(async (event) => {
-    const { targetUrl } = await useSalesChannel(event);
+    const { url, requestOptions } = await usePrepareRequest(event);
 
-    return await proxyRequest(event, `${targetUrl}${event.path}`);
+    return await proxyRequest(event, url, {
+        headers: requestOptions.headers,
+    });
 });


### PR DESCRIPTION
**Background:**

For tracking mobile application requests which got added with PR #2 the catch-all route for all non-cachable sections within the store (account, register, cart, etc.) we had to find a way to passthrough the headers here too.

**Solution:**

* Refactor utils usage
   *  Instead of using `useSalesChannel()` composable directly, we're using `usePreparedRequest()` which internally uses `useSalesChannel()` anyways
* Using built url instead of constructing it directly
* Passthrough headers from `usePreparedRequest()` to the proxy request 